### PR TITLE
Enable multi accounts

### DIFF
--- a/lib/omnifocus/pivotaltracker.rb
+++ b/lib/omnifocus/pivotaltracker.rb
@@ -20,11 +20,8 @@ module OmniFocus::Pivotaltracker
       abort "Created default config in #{path}. Go fill it out."
     end
 
-    if config.instance_of?(Array) then
-      config
-    else
-      [config]
-    end
+    # Make things working against single/multiple account settings.
+    [config].flatten
   end
 
   def populate_pivotaltracker_tasks


### PR DESCRIPTION
PivotalTracker plugin for omnifocus.rb is awesome. Only one point it lacks is support for multi accounts. I'm using PivotalTracker both for work and for personal tasks, so I tweaked this plugin a bit and added.

Config .yml should be look like the one below.

```
$ cat ~/.omnifocus-pivotaltracker.yml

---
- 
  :token: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
  :user_name: muo
- 
  :token: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
  :user_name: KN
```

Maybe someone would want "projects prefixing" feature for avoiding stories in different accounts merged into one when they have same project name, but it'd be another issue.
