### PR TITLE
Bump dependency version

### DIFF
--- a/omnifocus-pivotaltracker.gemspec
+++ b/omnifocus-pivotaltracker.gemspec
@@ -15,6 +15,6 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = OmniFocus::Pivotaltracker::VERSION
 
-  gem.add_dependency "omnifocus", "~> 2.0.0"
+  gem.add_dependency "omnifocus", "~> 2.1.3"
   gem.add_dependency "nokogiri", "~> 1.5.2"
 end


### PR DESCRIPTION
Hi. I noticed current released omnifocus.rb is 2.1.x and there are several improvements and fixes made in 2.1.x. However, omnifocus-pivotaltracker's dependency pattern ( http://guides.rubygems.org/patterns/ ) prevents omnifocus-pivotaltracker from working with 2.1.x with current spec (btw, 2.1.0 was released back in 2012 https://github.com/seattlerb/omnifocus/commit/0ec3e0a3bf7b ).

There could be lots of methods to work with this, but I guess putting base version as 2.1.3 and keeping up with minor updates (in 2.1.x) would be enough this time.